### PR TITLE
Fix macOS and Windows build failures by updating dependencies.

### DIFF
--- a/requirements_macos.txt
+++ b/requirements_macos.txt
@@ -1,6 +1,6 @@
 pefile==2019.4.18
 pycryptodome==3.9.8
-pyinstaller==4.0
+pyinstaller==5.13.0
 pyobjc-core==6.2.2
 pyobjc-framework-Cocoa==6.2.2
 PyQt5==5.13.1

--- a/requirements_win32.txt
+++ b/requirements_win32.txt
@@ -5,11 +5,11 @@ pycryptodome==3.10.1
 PyInstaller==5.9.0
 pyinstaller-hooks-contrib==2023.1
 pyparsing==3.0.9
-PyQt5==5.13.1
+PyQt5==5.14.0
 pywin32==300
 sip==5.2.0
 six==1.16.0
-python-slugify[Unidecode]==4.0.0 
+python-slugify[Unidecode]==4.0.0
 Unidecode==1.1.1
 pyuca==1.2
 python-dateutil


### PR DESCRIPTION
The macOS build was failing during the installation of `pyinstaller==4.0` on Python 3.11. This version is not compatible with modern Python build systems. This has been updated to `pyinstaller==5.13.0`, which is compatible and available on PyPI.

The Windows build was failing because `PyQt5==5.13.1` is not available for Python 3.11. This has been updated to `PyQt5==5.14.0`, which is the earliest version available for Python 3.11.